### PR TITLE
Build: error with timezone

### DIFF
--- a/courses/clfp2020/Dockerfile
+++ b/courses/clfp2020/Dockerfile
@@ -1,5 +1,13 @@
 FROM ubuntu:latest
 
+ENV TZ=Europe/Kiev
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Setup timezone
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime 
+        && echo $TZ > /etc/timezone
+
 # Generic dependencies.
 RUN apt-get update && apt-get install -y software-properties-common git
 


### PR DESCRIPTION
Configuring tzdata
------------------
Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.
1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
2. America     5. Arctic     8. Europe    11. SystemV
3. Antarctica  6. Asia       9. Indian    12. US
Geographic area: 8
Europe
^C
-------
Setting up keyboard-configuration (1.108ubuntu15) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring keyboard-configuration
----------------------------------

The layout of keyboards varies per country, with some countries having multiple
common layouts. Please select the country of origin for the keyboard of this
computer.

  1. Afghani                                     48. Irish
  2. Albanian                                    49. Italian
...    
  28. English (UK)                               75. Slovak
  29. English (US)                               76. Slovenian
...
  45. Icelandic                                  92. Vietnamese
  46. Indian                                     93. Wolof
  47. Iraqi
Country of origin for the keyboard: 
----------------------
To resolve the timezone issue. (line 3 and 7)
To resolve the keyboard issue. (line 5)